### PR TITLE
Switch to Python orchestrator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+venv/
+node_modules/
+package-lock.json
+.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # Super-AI
-Orchestrator
+
+Python orchestrator for running multiple OpenAI agents. The `superMFI`
+function triggers PCB design, circuit simulation, error analysis and diagram
+generation steps.
+
+## Setup
+
+Install dependencies and run the orchestrator:
+
+```bash
+pip install openai
+python orchestrator.py
+```

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -1,0 +1,93 @@
+import os
+import openai
+import asyncio
+
+# client config
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+# designPCB agent
+async def designPCB(params):
+    prompt = f"Design a PCB with these specifications: {params}"
+    response = await openai.Completion.acreate(
+        model="code-davinci-002",
+        prompt=prompt,
+        max_tokens=150,
+    )
+    output = response.choices[0].text.strip()
+    print("# call designPCB")
+    print(output)
+    return output
+
+# simulateCircuit agent
+async def simulateCircuit(circuit):
+    prompt = f"Simulate the following circuit and report issues: {circuit}"
+    response = await openai.Completion.acreate(
+        model="code-davinci-002",
+        prompt=prompt,
+        max_tokens=150,
+    )
+    output = response.choices[0].text.strip()
+    print("# call simulateCircuit")
+    print(output)
+    return output
+
+# analyzeErrors agent
+async def analyzeErrors(simResult):
+    prompt = f"Analyze these simulation results for errors: {simResult}"
+    response = await openai.Completion.acreate(
+        model="code-davinci-002",
+        prompt=prompt,
+        max_tokens=100,
+    )
+    output = response.choices[0].text.strip()
+    print("# call analyzeErrors")
+    print(output)
+    return output
+
+# drawCircuitDiagram agent
+async def drawCircuitDiagram(pcbData):
+    prompt = f"Generate a detailed circuit diagram for: {pcbData}"
+    response = await openai.Completion.acreate(
+        model="code-davinci-002",
+        prompt=prompt,
+        max_tokens=150,
+    )
+    output = response.choices[0].text.strip()
+    print("# call drawCircuitDiagram")
+    print(output)
+    return output
+
+# orchestrator logic
+async def superMFI(materialsList, motorSpecs, powerConfig):
+    print("Starting SuperMFI-AI")
+    params = {
+        "materialsList": materialsList,
+        "motorSpecs": motorSpecs,
+        "powerConfig": powerConfig,
+    }
+    pcbData = await designPCB(params)
+    simResult = await simulateCircuit(pcbData)
+
+    errorReport = await analyzeErrors(simResult)
+    if "error" in errorReport.lower():
+        print("# redesign due to errors")
+        pcbData = await designPCB({**params, "errorReport": errorReport})
+        simResult = await simulateCircuit(pcbData)
+
+    diagram = await drawCircuitDiagram(pcbData)
+    print("SuperMFI-AI completed")
+    return {
+        "pcbData": pcbData,
+        "simResult": simResult,
+        "diagram": diagram,
+    }
+
+if __name__ == "__main__":
+    asyncio.run(
+        superMFI(
+            ["motor", "resistors", "capacitors"],
+            {"type": "dc", "rpm": 1000},
+            {"voltage": "12V"},
+        )
+    )
+


### PR DESCRIPTION
## Summary
- replace Node.js orchestrator with a Python version
- update README instructions for Python
- update `.gitignore` for Python and remove Node files

## Testing
- `python orchestrator.py` *(fails: AuthenticationError: No API key provided)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c6851966883258f73e4695b4846b8