### PR TITLE
Add SuperMFI-AI orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Super-AI
+The orchestrator uses the official `openai` library.
 #sss
 Orchestrator
 

--- a/orchestrator.js
+++ b/orchestrator.js
@@ -1,45 +1,46 @@
-const { OpenAI } = require('@openai/openai');
+const OpenAI = require('openai');
 
+// initialize OpenAI client
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
 async function designPCB(params) {
   console.log('designPCB start'); // call designPCB
-  const res = await openai.createCompletion({
+  const res = await openai.completions.create({
     model: 'code-davinci-002',
     prompt: `Design a PCB with params: ${JSON.stringify(params)}`,
     max_tokens: 100
   });
-  return res.data.choices[0].text.trim();
+  return res.choices[0].text.trim();
 }
 
 async function simulateCircuit(circuit) {
   console.log('simulateCircuit start'); // call simulateCircuit
-  const res = await openai.createCompletion({
+  const res = await openai.completions.create({
     model: 'code-davinci-002',
     prompt: `Simulate circuit: ${circuit}`,
     max_tokens: 100
   });
-  return res.data.choices[0].text.trim();
+  return res.choices[0].text.trim();
 }
 
 async function analyzeErrors(simResult) {
   console.log('analyzeErrors start'); // call analyzeErrors
-  const res = await openai.createCompletion({
+  const res = await openai.completions.create({
     model: 'code-davinci-002',
     prompt: `Analyze simulation result for errors: ${simResult}`,
     max_tokens: 50
   });
-  return res.data.choices[0].text.includes('error');
+  return res.choices[0].text.includes('error');
 }
 
 async function drawCircuitDiagram(pcbData) {
   console.log('drawCircuitDiagram start'); // call drawCircuitDiagram
-  const res = await openai.createCompletion({
+  const res = await openai.completions.create({
     model: 'code-davinci-002',
     prompt: `Draw circuit diagram for: ${pcbData}`,
     max_tokens: 100
   });
-  return res.data.choices[0].text.trim();
+  return res.choices[0].text.trim();
 }
 
 // orchestrator logic

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "main": "orchestrator.js",
   "dependencies": {
-    "@openai/openai": "*"
+    "openai": "^5.3.0"
   }
 }


### PR DESCRIPTION
## Summary
- create `orchestrator.js` implementing the SuperMFI-AI orchestrator with OpenAI API calls
- add a `package.json` declaring the OpenAI dependency
- document setup steps in README

## Testing
- `node --check orchestrator.js`
- `npm install` *(fails: package `@openai/openai` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c6b1be6508325b71893276b06a3e0