### PR TITLE
Fix function spacing for flake8

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -5,6 +5,7 @@ import asyncio
 # client config
 openai.api_key = os.getenv("OPENAI_API_KEY")
 
+
 # designPCB agent
 async def designPCB(params):
     prompt = f"Design a PCB with these specifications: {params}"
@@ -17,6 +18,7 @@ async def designPCB(params):
     print("# call designPCB")
     print(output)
     return output
+
 
 # simulateCircuit agent
 async def simulateCircuit(circuit):
@@ -31,6 +33,7 @@ async def simulateCircuit(circuit):
     print(output)
     return output
 
+
 # analyzeErrors agent
 async def analyzeErrors(simResult):
     prompt = f"Analyze these simulation results for errors: {simResult}"
@@ -44,6 +47,7 @@ async def analyzeErrors(simResult):
     print(output)
     return output
 
+
 # drawCircuitDiagram agent
 async def drawCircuitDiagram(pcbData):
     prompt = f"Generate a detailed circuit diagram for: {pcbData}"
@@ -56,6 +60,7 @@ async def drawCircuitDiagram(pcbData):
     print("# call drawCircuitDiagram")
     print(output)
     return output
+
 
 # orchestrator logic
 async def superMFI(materialsList, motorSpecs, powerConfig):
@@ -90,4 +95,3 @@ if __name__ == "__main__":
             {"voltage": "12V"},
         )
     )
-

--- a/super_ai_agent.py
+++ b/super_ai_agent.py
@@ -5,6 +5,7 @@ import os
 PROMPT_FOLDER = "prompts"
 WAIT_AFTER_EACH_STEP = 1  # seconds
 
+
 def find_browser_input_box():
     # Not robust, replace with image-based detection later
     pyautogui.hotkey("ctrl", "l")  # Go to address bar
@@ -12,10 +13,12 @@ def find_browser_input_box():
     pyautogui.press("enter")  # Focus input
     time.sleep(WAIT_AFTER_EACH_STEP)
 
+
 def submit_prompt(prompt_text):
     pyautogui.write(prompt_text, interval=0.01)
     pyautogui.press("enter")
     time.sleep(WAIT_AFTER_EACH_STEP)
+
 
 def main():
     print("🧠 Super-AI Agent started.")
@@ -39,6 +42,7 @@ def main():
             time.sleep(5)
 
         time.sleep(10)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- ensure two blank lines surround top-level functions
- remove trailing newline from orchestrator
- confirm no E302/E305/W391 flake8 violations remain

## Testing
- `flake8 | head -n 20`
- `flake8 | grep -E "E302|E305|W391" || true`

------
https://chatgpt.com/codex/tasks/task_e_68613ef6f00083259db88b2bb2454d4c