### PR TITLE
Add processed prompts dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ venv/
 node_modules/
 package-lock.json
 .env
+prompts/processed/


### PR DESCRIPTION
## Summary
- extend `.gitignore` to ignore `prompts/processed/`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68613ef8e7b083258c05cab719e033dd